### PR TITLE
Minerva ag/support i2c telemetry command

### DIFF
--- a/common/hal/hal_i2c_target.c
+++ b/common/hal/hal_i2c_target.c
@@ -188,7 +188,7 @@ static int i2c_target_stop(struct i2c_slave_config *config)
 
 		/* if target queue is full, unregister the bus target to prevent next message handle */
 		if (!k_msgq_num_free_get(&data->target_wr_msgq_id)) {
-			LOG_DBG("Target queue is full, unregister bus[%d]", data->i2c_bus);
+			LOG_WRN("Target queue is full, unregister bus[%d]", data->i2c_bus);
 			do_i2c_target_unregister(data->i2c_bus);
 		}
 	}

--- a/common/hal/hal_i2c_target.h
+++ b/common/hal/hal_i2c_target.h
@@ -49,7 +49,8 @@ struct i2c_target_data {
 	/* TARGET READ - Not support pending messages storage */
 	uint32_t rd_buffer_idx; // message buffer index
 	struct i2c_msg_package target_rd_msg; // message's buffer and length
-	bool (*rd_data_collect_func)(void *); // do something before read first byte
+	bool (*rd_data_collect_func)(
+		void *); // do something before read first byte: Return false if need to skip data collect while target stop
 };
 
 struct _i2c_target_config {

--- a/meta-facebook/minerva-ag/src/platform/plat_fru.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_fru.h
@@ -21,6 +21,46 @@
 #define LOG_EEPROM_ADDR (0xA0 >> 1)
 #define CPLD_EEPROM_ADDR (0xA0 >> 1)
 
+#define CHASSIS_CUSTOM_DATA_MAX 24
+#define BOARD_CUSTOM_DATA_MAX 8
+#define PRODUCT_CUSTOM_DATA_MAX 8
+
+typedef struct {
+	uint8_t chassis_type;
+	char chassis_part_number[32];
+	char chassis_serial_number[32];
+	char chassis_custom_data[CHASSIS_CUSTOM_DATA_MAX][32];
+} ChassisInfo;
+
+typedef struct {
+	uint8_t language;
+	char board_mfg_date[32];
+	char board_mfg[32];
+	char board_product[32];
+	char board_serial[32];
+	char board_part_number[32];
+	char board_fru_id[32];
+	char board_custom_data[BOARD_CUSTOM_DATA_MAX][32];
+} BoardInfo;
+
+typedef struct {
+	uint8_t language;
+	char product_manufacturer[32];
+	char product_name[32];
+	char product_part_number[32];
+	char product_version[32];
+	char product_serial[32];
+	char product_asset_tag[32];
+	char product_fru_id[32];
+	char product_custom_data[PRODUCT_CUSTOM_DATA_MAX][32];
+} ProductInfo;
+
+typedef struct {
+	ChassisInfo chassis;
+	BoardInfo board;
+	ProductInfo product;
+} FRU_INFO;
+
 enum FRU_ID {
 	LOG_EEPROM_ID = 0x00,
 	CPLD_EEPROM_ID,
@@ -31,5 +71,6 @@ bool init_fru_info(void);
 void print_fru_info(void);
 bool plat_eeprom_write(uint32_t offset, uint8_t *data, uint16_t data_len);
 bool plat_eeprom_read(uint32_t offset, uint8_t *data, uint16_t data_len);
+FRU_INFO *get_fru_info(void);
 
 #endif

--- a/meta-facebook/minerva-ag/src/platform/plat_hook.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.c
@@ -75,6 +75,7 @@ bool post_all_sensor_read(sensor_cfg *cfg, void *args, int *reading)
 	ARG_UNUSED(args);
 
 	update_sensor_data_2_5_table();
+	update_sensor_data_8_table();
 
 	return true;
 }

--- a/meta-facebook/minerva-ag/src/platform/plat_hook.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.c
@@ -52,6 +52,20 @@ int32_t alert_level_mA_default = 110000;
 int32_t alert_level_mA_user_setting = 110000;
 bool alert_level_is_assert = false;
 
+static uint8_t reverse_bits(uint8_t byte, uint8_t bit_cnt)
+{
+	uint8_t reversed_byte = 0;
+	for (int i = 0; i < bit_cnt; i++) {
+		if (byte & 1)
+			reversed_byte = (reversed_byte << 1) + 1;
+		else
+			reversed_byte = reversed_byte << 1;
+
+		byte = byte >> 1;
+	}
+	return reversed_byte;
+}
+
 int power_level_send_event(bool is_assert, int ubc1_current, int ubc2_current)
 {
 	if (is_assert == true) {
@@ -305,35 +319,35 @@ bool temp_sensor_rail_enum_get(uint8_t *name, uint8_t *num)
 // clang-format off
 bootstrap_mapping_register bootstrap_table[] = {
 	//  - JTAG pins - Ref 13.3.9 Athena datasheet 1.1
-	{ STRAP_INDEX_SOC_JTAG_MUX_SEL_0_3, 0x1E, "SOC_JTAG_MUX_SEL_0_3", { 4, 5, 6, 7 }, 4, 0x00, 0x00 },
-	{ STRAP_INDEX_SOC_DFT_TAP_EN_L, 0x38, "SOC_DFT_TAP_EN_L", { 1 }, 1, 0xFF, 0xFF },
+	{ STRAP_INDEX_SOC_JTAG_MUX_SEL_0_3, 0x1E, "SOC_JTAG_MUX_SEL_0_3", 4, 4, 0x01, 0x01, true},
+	{ STRAP_INDEX_SOC_DFT_TAP_EN_L, 0x38, "SOC_DFT_TAP_EN_L", 1, 1, 0x01, 0x01, false},
 	// - TEST pins - Ref 13.3.12 Athena datasheet
-	{ STRAP_INDEX_SOC_ATPG_MODE_L, 0x38, "SOC_ATPG_MODE_L", { 2 }, 1, 0xFF, 0xFF },
-	{ STRAP_INDEX_SOC_PAD_TRI_L, 0x38, "SOC_PAD_TRI_L", { 3 }, 1, 0xFF, 0xFF },
-	{ STRAP_INDEX_SOC_CORE_TAP_CTRL_L, 0x38, "SOC_CORE_TAP_CTRL_L", { 0 }, 1, 0xFF, 0xFF },
+	{ STRAP_INDEX_SOC_ATPG_MODE_L, 0x38, "SOC_ATPG_MODE_L", 2, 1, 0x01, 0x01, false },
+	{ STRAP_INDEX_SOC_PAD_TRI_N, 0x38, "SOC_PAD_TRI_N", 3, 1, 0x01, 0x01, false },
+	{ STRAP_INDEX_SOC_CORE_TAP_CTRL_L, 0x38, "SOC_CORE_TAP_CTRL_L", 0, 1, 0x01, 0x01, false },
 	// - SOC BOOT SOURCE pins - Ref 12.3 Athena datasheet
-	{ STRAP_INDEX_SOC_BOOT_SOURCE_0_4, 0x21, "SOC_BOOT_SOURCE_0_4", { 0, 1, 2, 3, 4 }, 5, 0x00, 0x00 },
-	{ STRAP_INDEX_SOC_BOOT_SOURCE_5_6, 0x21, "SOC_BOOT_SOURCE_5_6", { 5, 6 }, 2, 0x00, 0x00 },
-	{ STRAP_INDEX_SOC_BOOT_SOURCE_7, 0x21, "SOC_BOOT_SOURCE_7", { 7 }, 1, 0x00, 0x00 },
-	{ STRAP_INDEX_SOC_GPIO2, 0x3B, "SOC_GPIO2", { 0 }, 1, 0x00, 0x00 },
+	{ STRAP_INDEX_SOC_BOOT_SOURCE_0_4, 0x21, "SOC_BOOT_SOURCE_0_4", 0, 5, 0x00, 0x00, false },
+	{ STRAP_INDEX_SOC_BOOT_SOURCE_5_6, 0x21, "SOC_BOOT_SOURCE_5_6", 5, 2, 0x00, 0x00, false },
+	{ STRAP_INDEX_SOC_BOOT_SOURCE_7, 0x21, "SOC_BOOT_SOURCE_7", 7, 1, 0x00, 0x00, false },
+	{ STRAP_INDEX_SOC_GPIO2, 0x3B, "SOC_GPIO2", 0, 1, 0x00, 0x00, false },
 	// - OWL BOOT SOURCE pins -
-	{ STRAP_INDEX_S_OWL_BOOT_SOURCE_0_7, 0x22, "S_OWL_BOOT_SOURCE_0_7", { 0, 1, 2, 3, 4, 5, 6, 7 }, 8, 0x00, 0x00 },
-	{ STRAP_INDEX_N_OWL_BOOT_SOURCE_0_7, 0x23, "N_OWL_BOOT_SOURCE_0_7", { 0, 1, 2, 3, 4, 5, 6, 7 }, 8, 0x00, 0x00 },
+	{ STRAP_INDEX_S_OWL_BOOT_SOURCE_0_7, 0x22, "S_OWL_BOOT_SOURCE_0_7", 0, 8, 0x00, 0x00, false },
+	{ STRAP_INDEX_N_OWL_BOOT_SOURCE_0_7, 0x23, "N_OWL_BOOT_SOURCE_0_7", 0, 8, 0x00, 0x00, false },
 	// - OWL TEST pins -
-	{ STRAP_INDEX_S_OWL_PAD_TRI_L, 0x37, "S_OWL_PAD_TRI_L", { 3 }, 1, 0xFF, 0xFF },
-	{ STRAP_INDEX_S_OWL_ATPG_MODE_L, 0x37, "S_OWL_ATPG_MODE_L", { 2 }, 1, 0xFF, 0xFF },
-	{ STRAP_INDEX_S_OWL_DFT_TAP_EN_L, 0x37, "S_OWL_DFT_TAP_EN_L", { 1 }, 1, 0xFF, 0xFF },
-	{ STRAP_INDEX_S_OWL_CORE_TAP_CTRL_L, 0x37, "S_OWL_CORE_TAP_CTRL_L", { 0 }, 1, 0xFF, 0xFF },
-	{ STRAP_INDEX_N_OWL_PAD_TRI_L, 0x36, "N_OWL_PAD_TRI_L", { 3 }, 1, 0xFF, 0xFF },
-	{ STRAP_INDEX_N_OWL_ATPG_MODE_L, 0x36, "N_OWL_ATPG_MODE_L", { 2 }, 1, 0xFF, 0xFF },
-	{ STRAP_INDEX_N_OWL_DFT_TAP_EN_L, 0x36, "N_OWL_DFT_TAP_EN_L", { 1 }, 1, 0xFF, 0xFF },
-	{ STRAP_INDEX_N_OWL_CORE_TAP_CTRL_L, 0x36, "N_OWL_CORE_TAP_CTRL_L", { 0 }, 1, 0xFF, 0xFF },
+	{ STRAP_INDEX_S_OWL_PAD_TRI_N, 0x37, "S_OWL_PAD_TRI_N", 3, 1, 0x01, 0x01, false },
+	{ STRAP_INDEX_S_OWL_ATPG_MODE_L, 0x37, "S_OWL_ATPG_MODE_L", 2, 1, 0x01, 0x01, false },
+	{ STRAP_INDEX_S_OWL_DFT_TAP_EN_L, 0x37, "S_OWL_DFT_TAP_EN_L", 1, 1, 0x01, 0x01, false },
+	{ STRAP_INDEX_S_OWL_CORE_TAP_CTRL_L, 0x37, "S_OWL_CORE_TAP_CTRL_L", 0, 1, 0x01, 0x01, false },
+	{ STRAP_INDEX_N_OWL_PAD_TRI_N, 0x36, "N_OWL_PAD_TRI_N", 3, 1, 0x01, 0x01, false },
+	{ STRAP_INDEX_N_OWL_ATPG_MODE_L, 0x36, "N_OWL_ATPG_MODE_L", 2, 1, 0x01, 0x01, false },
+	{ STRAP_INDEX_N_OWL_DFT_TAP_EN_L, 0x36, "N_OWL_DFT_TAP_EN_L", 1, 1, 0x01, 0x01, false },
+	{ STRAP_INDEX_N_OWL_CORE_TAP_CTRL_L, 0x36, "N_OWL_CORE_TAP_CTRL_L", 0, 1, 0x01, 0x01, false },
 	// - OWL JTAG pin -
-	{ STRAP_INDEX_S_OWL_JTAG_MUX_SEL_0_3, 0x1D, "S_OWL_JTAG_MUX_SEL_0_3", { 3, 2, 1, 0 }, 4, 0x00, 0x00 },
-	{ STRAP_INDEX_N_OWL_JTAG_MUX_SEL_0_3, 0x1D, "N_OWL_JTAG_MUX_SEL_0_3", { 7, 6, 5, 4 }, 4, 0x00, 0x00 },
+	{ STRAP_INDEX_S_OWL_JTAG_MUX_SEL_0_3, 0x1D, "S_OWL_JTAG_MUX_SEL_0_3", 0, 4, 0x01, 0x01, true },
+	{ STRAP_INDEX_N_OWL_JTAG_MUX_SEL_0_3, 0x1D, "N_OWL_JTAG_MUX_SEL_0_3", 4, 4, 0x01, 0x01, true },
 	// - OWL UART pin -
-	{ STRAP_INDEX_S_OWL_UART_MUX_SEL_0_2, 0x1F, "S_OWL_UART_MUX_SEL_0_2", { 4, 3, 2 }, 3, 0x00, 0x00 },
-	{ STRAP_INDEX_N_OWL_UART_MUX_SEL_0_2, 0x1F, "N_OWL_UART_MUX_SEL_0_2", { 7, 6, 5 }, 3, 0x00, 0x00 },
+	{ STRAP_INDEX_S_OWL_UART_MUX_SEL_0_2, 0x1F, "S_OWL_UART_MUX_SEL_0_2", 2, 3, 0x00, 0x00, true },
+	{ STRAP_INDEX_N_OWL_UART_MUX_SEL_0_2, 0x1F, "N_OWL_UART_MUX_SEL_0_2", 5, 3, 0x00, 0x00, true },
 };
 // clang-format on
 
@@ -1135,46 +1149,47 @@ bool bootstrap_user_settings_set(void *bootstrap_user_settings)
 }
 
 bool set_bootstrap_table_and_user_settings(uint8_t rail, uint8_t *change_setting_value,
-					   uint8_t drive_index_level, bool is_perm)
+					   uint8_t drive_index_level, bool is_perm, bool is_default)
 {
 	if (rail >= STRAP_INDEX_MAX)
 		return false;
 
+	*change_setting_value = 0;
 	for (int i = 0; i < STRAP_INDEX_MAX; i++) {
 		if (bootstrap_table[i].index == rail) {
-			uint8_t mask = 0;
-			for (int j = 0; j < bootstrap_table[i].bit_count; j++) {
-				mask |= (1 << bootstrap_table[i].bits[j]);
-			}
+			bootstrap_table[i].change_setting_value =
+				(is_default) ? bootstrap_table[i].default_setting_value :
+					       drive_index_level;
 
-			// If cpld_offsets is the same, update the change_setting_value together
-			for (int k = 0; k < STRAP_INDEX_MAX; k++) {
-				if (bootstrap_table[k].cpld_offsets ==
+			// get whole cpld register value to set
+			for (int j = 0; j < STRAP_INDEX_MAX; j++) {
+				if (bootstrap_table[j].cpld_offsets ==
 				    bootstrap_table[i].cpld_offsets) {
-					switch (drive_index_level) {
-					case DRIVE_INDEX_LEVEL_HIGH:
-						bootstrap_table[k].change_setting_value |=
-							mask; // set 1
-						break;
-					case DRIVE_INDEX_LEVEL_LOW:
-						bootstrap_table[k].change_setting_value &=
-							~mask; // set 0
-						break;
-					case DRIVE_INDEX_LEVEL_DEFAULT:
-						// Clear the specified bit
-						bootstrap_table[k].change_setting_value &= ~mask;
-						// Reset the specified bit to default_setting_value
-						bootstrap_table[k].change_setting_value |=
-							(bootstrap_table[k].default_setting_value &
-							 mask);
-						break;
+					uint8_t tmp_reverse = 0;
+					if (bootstrap_table[j].reverse)
+						tmp_reverse = reverse_bits(
+							bootstrap_table[j].change_setting_value,
+							bootstrap_table[j].bit_count);
 
-					default:
-						break;
+					for (int k = 0; k < bootstrap_table[j].bit_count; k++) {
+						if (bootstrap_table[j].reverse) {
+							if (tmp_reverse & BIT(k))
+								*change_setting_value |= BIT(
+									k + bootstrap_table[j]
+										    .bit_offset);
+						} else {
+							if (bootstrap_table[j].change_setting_value &
+							    BIT(k))
+								*change_setting_value |= BIT(
+									k + bootstrap_table[j]
+										    .bit_offset);
+						}
 					}
 				}
 			}
-			*change_setting_value = bootstrap_table[i].change_setting_value;
+
+			LOG_DBG("set [%2d]%s: %02x", rail, bootstrap_table[i].strap_name,
+				*change_setting_value);
 			/*
 				save perm parameter to bootstrap_user_settings
 				bit 8: not perm(ff); perm(1)
@@ -1214,11 +1229,9 @@ static bool bootstrap_user_settings_init(void)
 			// write bootstrap_table
 			uint8_t change_setting_value;
 			uint8_t drive_index_level =
-				((bootstrap_user_settings.user_setting_value[i] & 0xff) == 0x00) ?
-					DRIVE_INDEX_LEVEL_LOW :
-					DRIVE_INDEX_LEVEL_HIGH;
-			if (!set_bootstrap_table_and_user_settings(i, &change_setting_value,
-								   drive_index_level, false)) {
+				bootstrap_user_settings.user_setting_value[i] & 0xFF;
+			if (!set_bootstrap_table_and_user_settings(
+				    i, &change_setting_value, drive_index_level, false, false)) {
 				LOG_ERR("set bootstrap_table[%2d]:%d failed", i, drive_index_level);
 				return false;
 			}
@@ -1250,7 +1263,16 @@ static bool bootstrap_default_settings_init(void)
 			LOG_ERR("Can't find bootstrap default by rail index from cpld: %d", i);
 			return false;
 		}
-		bootstrap_table[i].change_setting_value = data;
+
+		uint8_t mask =
+			GENMASK(bootstrap_table[i].bit_offset + bootstrap_table[i].bit_count - 1,
+				bootstrap_table[i].bit_offset);
+		bootstrap_table[i].change_setting_value =
+			(data & mask) >> bootstrap_table[i].bit_offset;
+		if (bootstrap_table[i].reverse)
+			bootstrap_table[i].change_setting_value =
+				reverse_bits(bootstrap_table[i].change_setting_value,
+					     bootstrap_table[i].bit_count);
 	}
 	return true;
 }
@@ -1278,13 +1300,9 @@ bool get_bootstrap_change_drive_level(int rail, int *drive_level)
 		LOG_ERR("Can't find strap_item by rail index: %d", rail);
 		return false;
 	}
-	uint8_t mask = 0;
-	// Calculate mask to indicate the bits affected by the bootstrap_item
-	for (int i = 0; i < bootstrap_item.bit_count; i++) {
-		mask |= (1 << bootstrap_item.bits[i]);
-	}
 
-	*drive_level = (bootstrap_item.change_setting_value & mask) ? true : false;
+	*drive_level = bootstrap_item.change_setting_value;
+	LOG_DBG("rail %d, drive_level = %x", rail, *drive_level);
 	return true;
 }
 

--- a/meta-facebook/minerva-ag/src/platform/plat_hook.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.c
@@ -37,6 +37,7 @@
 #include "plat_pldm_sensor.h"
 #include "plat_class.h"
 #include "pmbus.h"
+#include "plat_i2c_target.h"
 
 LOG_MODULE_REGISTER(plat_hook);
 
@@ -66,6 +67,16 @@ int power_level_send_event(bool is_assert, int ubc1_current, int ubc2_current)
 	}
 
 	return 0;
+}
+
+bool post_all_sensor_read(sensor_cfg *cfg, void *args, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	ARG_UNUSED(args);
+
+	update_sensor_data_2_5_table();
+
+	return true;
 }
 
 bool post_ubc_read(sensor_cfg *cfg, void *args, int *reading)

--- a/meta-facebook/minerva-ag/src/platform/plat_hook.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.c
@@ -1148,6 +1148,13 @@ bool bootstrap_user_settings_set(void *bootstrap_user_settings)
 	return true;
 }
 
+bool check_is_bootstrap_setting_value_valid(uint8_t rail, uint8_t value)
+{
+	int critical_value = 1 << bootstrap_table[rail].bit_count;
+
+	return value < critical_value;
+}
+
 bool set_bootstrap_table_and_user_settings(uint8_t rail, uint8_t *change_setting_value,
 					   uint8_t drive_index_level, bool is_perm, bool is_default)
 {
@@ -1157,9 +1164,14 @@ bool set_bootstrap_table_and_user_settings(uint8_t rail, uint8_t *change_setting
 	*change_setting_value = 0;
 	for (int i = 0; i < STRAP_INDEX_MAX; i++) {
 		if (bootstrap_table[i].index == rail) {
-			bootstrap_table[i].change_setting_value =
-				(is_default) ? bootstrap_table[i].default_setting_value :
-					       drive_index_level;
+			drive_index_level = (is_default) ?
+						    bootstrap_table[i].default_setting_value :
+						    drive_index_level;
+			if (!check_is_bootstrap_setting_value_valid(rail, drive_index_level)) {
+				LOG_ERR("hex-value :0x%x is out of range", drive_index_level);
+				return false;
+			}
+			bootstrap_table[i].change_setting_value = drive_index_level;
 
 			// get whole cpld register value to set
 			for (int j = 0; j < STRAP_INDEX_MAX; j++) {

--- a/meta-facebook/minerva-ag/src/platform/plat_hook.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.h
@@ -110,7 +110,7 @@ enum PLAT_STRAP_INDEX_E {
 	STRAP_INDEX_SOC_JTAG_MUX_SEL_0_3,
 	STRAP_INDEX_SOC_DFT_TAP_EN_L,
 	STRAP_INDEX_SOC_ATPG_MODE_L,
-	STRAP_INDEX_SOC_PAD_TRI_L,
+	STRAP_INDEX_SOC_PAD_TRI_N,
 	STRAP_INDEX_SOC_CORE_TAP_CTRL_L,
 	STRAP_INDEX_SOC_BOOT_SOURCE_0_4,
 	STRAP_INDEX_SOC_BOOT_SOURCE_5_6,
@@ -118,11 +118,11 @@ enum PLAT_STRAP_INDEX_E {
 	STRAP_INDEX_SOC_GPIO2,
 	STRAP_INDEX_S_OWL_BOOT_SOURCE_0_7,
 	STRAP_INDEX_N_OWL_BOOT_SOURCE_0_7,
-	STRAP_INDEX_S_OWL_PAD_TRI_L,
+	STRAP_INDEX_S_OWL_PAD_TRI_N,
 	STRAP_INDEX_S_OWL_ATPG_MODE_L,
 	STRAP_INDEX_S_OWL_DFT_TAP_EN_L,
 	STRAP_INDEX_S_OWL_CORE_TAP_CTRL_L,
-	STRAP_INDEX_N_OWL_PAD_TRI_L,
+	STRAP_INDEX_N_OWL_PAD_TRI_N,
 	STRAP_INDEX_N_OWL_ATPG_MODE_L,
 	STRAP_INDEX_N_OWL_DFT_TAP_EN_L,
 	STRAP_INDEX_N_OWL_CORE_TAP_CTRL_L,
@@ -131,12 +131,6 @@ enum PLAT_STRAP_INDEX_E {
 	STRAP_INDEX_S_OWL_UART_MUX_SEL_0_2,
 	STRAP_INDEX_N_OWL_UART_MUX_SEL_0_2,
 	STRAP_INDEX_MAX,
-};
-
-enum PLAT_DRIVE_LEVEL_INDEX_E {
-	DRIVE_INDEX_LEVEL_LOW = 1,
-	DRIVE_INDEX_LEVEL_HIGH,
-	DRIVE_INDEX_LEVEL_DEFAULT,
 };
 
 typedef struct vr_vout_range_user_settings_struct {
@@ -221,10 +215,11 @@ typedef struct bootstrap_mapping_register {
 	uint8_t index;
 	uint8_t cpld_offsets;
 	uint8_t *strap_name;
-	uint8_t bits[8];
+	uint8_t bit_offset;
 	uint8_t bit_count;
 	uint8_t default_setting_value;
 	uint8_t change_setting_value;
+	bool reverse;
 } bootstrap_mapping_register;
 
 bool plat_get_vout_range(uint8_t rail, uint16_t *vout_max_millivolt, uint16_t *vout_min_millivolt);
@@ -274,7 +269,8 @@ bool strap_name_get(uint8_t rail, uint8_t **name);
 bool strap_enum_get(uint8_t *name, uint8_t *num);
 bool find_bootstrap_by_rail(uint8_t rail, bootstrap_mapping_register *result);
 bool set_bootstrap_table_and_user_settings(uint8_t rail, uint8_t *change_setting_value,
-					   uint8_t drive_index_level, bool is_perm);
+					   uint8_t drive_index_level, bool is_perm,
+					   bool is_default);
 bool get_bootstrap_change_drive_level(int rail, int *drive_level);
 void init_temp_limit(void);
 

--- a/meta-facebook/minerva-ag/src/platform/plat_hook.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.h
@@ -244,6 +244,7 @@ bool vr_rail_name_get(uint8_t rail, uint8_t **name);
 bool vr_rail_enum_get(uint8_t *name, uint8_t *num);
 int power_level_send_event(bool is_assert, int ubc1_current, int ubc2_current);
 bool post_ubc_read(sensor_cfg *cfg, void *args, int *reading);
+bool post_all_sensor_read(sensor_cfg *cfg, void *args, int *reading);
 void set_uart_power_event_is_enable(bool is_enable);
 void pwr_level_mutex_init(void);
 void set_alert_level_to_default_or_user_setting(bool is_default, int32_t user_setting);

--- a/meta-facebook/minerva-ag/src/platform/plat_i2c_target.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_i2c_target.c
@@ -27,17 +27,332 @@
 #include <zephyr.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include "libutil.h"
 #include "plat_i2c_target.h"
+#include "plat_i2c.h"
+#include <logging/log.h>
+#include "plat_gpio.h"
+#include "plat_pldm_sensor.h"
+#include "pldm_sensor.h"
+#include "plat_version.h"
+#include "plat_isr.h"
 
+#define DEVICE_TYPE 0x01
+#define REGISTER_LAYOUT_VERSION 0x01
+#define AEGIS_CARRIER_BOARD_ID 0x0000
+#define AEGIS_CPLD_ADDR (0x4C >> 1)
+#define DATA_TABLE_LENGTH_1 1
+#define DATA_TABLE_LENGTH_2 2
+#define DATA_TABLE_LENGTH_4 4
+#define DATA_TABLE_LENGTH_7 7
+#define SENSOR_INIT_PDR_INDEX_MAX 248 // PDR indexe is on 0 base
+#define SENSOR_READING_PDR_INDEX_MAX 50
+
+typedef struct __attribute__((__packed__)) {
+	uint8_t device_type;
+	uint8_t register_layout_version;
+	uint8_t num_idx; //Number of PDR indexes in this register
+	uint8_t reserved_1;
+
+	uint16_t sbi; //Sensor base index (SBI= 248*R) used in this register's array
+	uint16_t max_pdr_idx; //Max PDR sensor index exported in total (MAX_PDRIDX)
+
+	uint8_t sensor_r_len[]; //sensor[0] reading length ~ sensor[247] reading length
+} plat_sensor_init_data_0_1;
+// size = sizeof(plat_sensor_init_data_0_1) + num_idx
+
+typedef struct __attribute__((__packed__)) {
+	uint8_t sensor_index_offset; // Sensor index offset (e.g. PDR sensor index offset)
+	uint32_t sensor_value; // Sensor value (4 bytes)
+} sensor_entry;
+
+typedef struct __attribute__((__packed__)) {
+	uint8_t device_type; // Device type (Aegis = 0x01, Rainbow = 0x02)
+	uint8_t register_layout_version; // Register layout version (e.g. VERSION_1 = 0x01)
+	uint16_t sensor_base_index; // Sensor base index (SBI)
+	uint8_t max_sbi_off; // Max sensor base index offset in this register (0 <= MAX_SBI_OFF <= 49)
+	// The following is a flexible array of sensor entries.
+	// The number of entries is (max_sbi_off + 1)
+	sensor_entry sensor_entries[];
+} plat_sensor_init_data_2_5;
+// size = sizeof(plat_sensor_init_data_2_5) + num_sensors * sizeof(SensorEntry);
+// num_sensors = max_sbi_off + 1
+
+typedef struct __attribute__((__packed__)) {
+	uint16_t carrier_board_id; //  MTIA Gen1 - Aegis=0x00
+	uint32_t bic_fw_version;
+	uint32_t cpld_fw_version;
+} plat_sensor_init_data_6;
+// size = sizeof(plat_sensor_init_data_6)
+
+LOG_MODULE_REGISTER(plat_i2c_target);
 /* I2C target init-enable table */
 const bool I2C_TARGET_ENABLE_TABLE[MAX_TARGET_NUM] = {
 	TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE, TARGET_ENABLE,
-	TARGET_DISABLE, TARGET_ENABLE,	TARGET_DISABLE, TARGET_DISABLE,
+	TARGET_DISABLE, TARGET_DISABLE, TARGET_ENABLE,	TARGET_DISABLE,
 	TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE,
 };
 
+plat_sensor_init_data_0_1 *sensor_init_data_0_1_table[DATA_TABLE_LENGTH_2] = { NULL };
+plat_sensor_init_data_2_5 *sensor_init_data_2_5_table[DATA_TABLE_LENGTH_4] = { NULL };
+plat_sensor_init_data_6 *sensor_init_data_6_table[DATA_TABLE_LENGTH_1] = { NULL };
+
+void *allocate_sensor_data_table(void **buffer, size_t buffer_size)
+{
+	if (*buffer) {
+		free(*buffer);
+		*buffer = NULL;
+	}
+
+	*buffer = malloc(buffer_size);
+	if (!*buffer) {
+		LOG_ERR("Memory allocation failed!");
+		return NULL;
+	}
+	return *buffer;
+}
+
+bool initialize_sensor_data_0_1(telemetry_info *telemetry_info, uint8_t *buffer_size)
+{
+	CHECK_NULL_ARG_WITH_RETURN(telemetry_info, false);
+
+	int table_index = telemetry_info->telemetry_offset - SENSOR_INIT_DATA_0_REG;
+	if (table_index < 0 || table_index >= DATA_TABLE_LENGTH_2)
+		return false;
+
+	// Calculate num_idx
+	int num_idx = (PLAT_SENSOR_NUM_MAX - 1) - (SENSOR_INIT_PDR_INDEX_MAX * table_index);
+	num_idx = (num_idx > 0) ?
+			  ((num_idx > SENSOR_INIT_PDR_INDEX_MAX) ? SENSOR_INIT_PDR_INDEX_MAX :
+								   num_idx) :
+			  0;
+
+	// Calculate the memory size
+	size_t table_size = sizeof(plat_sensor_init_data_0_1) + num_idx * sizeof(uint8_t);
+	plat_sensor_init_data_0_1 *sensor_data = allocate_sensor_data_table(
+		(void **)&sensor_init_data_0_1_table[table_index], table_size);
+	if (!sensor_data)
+		return false;
+
+	sensor_data->device_type = DEVICE_TYPE;
+	sensor_data->register_layout_version = REGISTER_LAYOUT_VERSION;
+	sensor_data->num_idx = num_idx;
+	sensor_data->reserved_1 = 0xFF;
+	sensor_data->sbi = table_index * SENSOR_INIT_PDR_INDEX_MAX;
+	sensor_data->max_pdr_idx = (table_index == 0x00) ? PLAT_SENSOR_NUM_MAX - 2 : 0xFFFF;
+	memset(sensor_data->sensor_r_len, 4, num_idx * sizeof(uint8_t));
+
+	*buffer_size = (uint8_t)table_size;
+	return true;
+}
+
+bool initialize_sensor_data_2_5(telemetry_info *telemetry_info, uint8_t *buffer_size)
+{
+	CHECK_NULL_ARG_WITH_RETURN(telemetry_info, false);
+
+	int table_index = telemetry_info->telemetry_offset - SENSOR_READING_0_REG;
+	if (table_index < 0 || table_index >= DATA_TABLE_LENGTH_4)
+		return false;
+
+	int num_idx = (PLAT_SENSOR_NUM_MAX - 1) - (SENSOR_READING_PDR_INDEX_MAX * table_index);
+	num_idx = (num_idx > 0) ?
+			  ((num_idx > SENSOR_READING_PDR_INDEX_MAX) ? SENSOR_READING_PDR_INDEX_MAX :
+								      num_idx) :
+			  0;
+
+	size_t table_size = sizeof(plat_sensor_init_data_2_5) + num_idx * sizeof(sensor_entry);
+	plat_sensor_init_data_2_5 *sensor_data = allocate_sensor_data_table(
+		(void **)&sensor_init_data_2_5_table[table_index], table_size);
+	if (!sensor_data)
+		return false;
+
+	sensor_data->device_type = DEVICE_TYPE;
+	sensor_data->register_layout_version = REGISTER_LAYOUT_VERSION;
+	sensor_data->sensor_base_index = table_index * SENSOR_READING_PDR_INDEX_MAX;
+	sensor_data->max_sbi_off = (num_idx > 0) ? num_idx - 1 : 0;
+	for (int i = 0; i < num_idx; i++) {
+		sensor_data->sensor_entries[i].sensor_index_offset =
+			i; // sensor_index_offset range: 0~49
+		sensor_data->sensor_entries[i].sensor_value = 0x00000000;
+	}
+
+	*buffer_size = (uint8_t)table_size;
+	return true;
+}
+
+bool initialize_sensor_data_6(telemetry_info *telemetry_info, uint8_t *buffer_size)
+{
+	CHECK_NULL_ARG_WITH_RETURN(telemetry_info, false);
+
+	int table_index = telemetry_info->telemetry_offset - INVENTORY_IDS_REG;
+	if (table_index < 0 || table_index >= DATA_TABLE_LENGTH_1)
+		return false;
+
+	size_t table_size = sizeof(plat_sensor_init_data_6);
+	plat_sensor_init_data_6 *sensor_data = allocate_sensor_data_table(
+		(void **)&sensor_init_data_6_table[table_index], table_size);
+	if (!sensor_data)
+		return false;
+
+	uint8_t data[4] = { 0 };
+	uint32_t bic_version = 0;
+	uint32_t cpld_version = 0;
+	if (!plat_i2c_read(I2C_BUS5, AEGIS_CPLD_ADDR, 0x44, data, 4)) {
+		LOG_ERR("Failed to read cpld version from cpld");
+		return false;
+	}
+	cpld_version = (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
+	bic_version =
+		(BIC_FW_YEAR_MSB << 24) | (BIC_FW_YEAR_LSB << 16) | (BIC_FW_WEEK << 8) | BIC_FW_VER;
+
+	sensor_data->carrier_board_id = AEGIS_CARRIER_BOARD_ID;
+	sensor_data->bic_fw_version = bic_version;
+	sensor_data->cpld_fw_version = cpld_version;
+
+	*buffer_size = (uint8_t)table_size;
+	return true;
+}
+
+void update_sensor_data_2_5_table()
+{
+	for (int table_index = 0; table_index < DATA_TABLE_LENGTH_4; table_index++) {
+		if (!sensor_init_data_2_5_table[table_index])
+			continue;
+
+		plat_sensor_init_data_2_5 *sensor_data = sensor_init_data_2_5_table[table_index];
+		int num_idx = sensor_data->max_sbi_off + 1;
+
+		for (int i = 0; i < num_idx; i++) {
+			int sensor_number =
+				sensor_data->sensor_base_index + i + 1; // sensor number is 1 base
+			uint8_t status = SENSOR_UNAVAILABLE;
+			int reading = 0;
+			uint8_t sensor_operational_state = PLDM_SENSOR_STATUSUNKOWN;
+
+			status = pldm_sensor_get_reading_from_cache(sensor_number, &reading,
+								    &sensor_operational_state);
+			sensor_data->sensor_entries[i].sensor_value =
+				(status == SENSOR_READ_SUCCESS) ? reading : 0xFFFFFFFF;
+		}
+	}
+}
+
+telemetry_info telemetry_info_table[] = {
+	{ SENSOR_INIT_DATA_0_REG, 0x00, .sensor_data_init = initialize_sensor_data_0_1 },
+	{ SENSOR_INIT_DATA_1_REG, 0x00, .sensor_data_init = initialize_sensor_data_0_1 },
+	{ SENSOR_READING_0_REG, 0x00, .sensor_data_init = initialize_sensor_data_2_5 },
+	{ SENSOR_READING_1_REG, 0x00, .sensor_data_init = initialize_sensor_data_2_5 },
+	{ SENSOR_READING_2_REG, 0x00, .sensor_data_init = initialize_sensor_data_2_5 },
+	{ SENSOR_READING_3_REG, 0x00, .sensor_data_init = initialize_sensor_data_2_5 },
+	{ INVENTORY_IDS_REG, 0x00, .sensor_data_init = initialize_sensor_data_6 },
+	{ OWL_NIC_MAC_ADDRESSES_REG },
+	{ STRAP_CAPABILTITY_REG },
+	{ WRITE_STRAP_PIN_VALUE_REG },
+	{ FRU_BOARD_PART_NUMBER_REG },
+	{ FRU_BOARD_SERIAL_NUMBER_REG },
+	{ FRU_BOARD_PRODUCT_NAME_REG },
+	{ FRU_BOARD_CUSTOM_DATA_1_REG },
+	{ FRU_BOARD_CUSTOM_DATA_2_REG },
+	{ FRU_BOARD_CUSTOM_DATA_3_REG },
+	{ FRU_BOARD_CUSTOM_DATA_4_REG },
+	{ FRU_PRODUCT_NAME_REG },
+	{ FRU_PRODUCT_PART_NUMBER_REG },
+	{ FRU_PRODUCT_PART_VERSION_REG },
+	{ FRU_PRODUCT_SERIAL_NUMBER_REG },
+	{ FRU_PRODUCT_ASSET_TAG_REG },
+	{ FRU_PRODUCT_CUSTOM_DATA_1_REG },
+	{ FRU_PRODUCT_CUSTOM_DATA_2_REG },
+};
+
+static bool command_reply_data_handle(void *arg)
+{
+	struct i2c_target_data *data = (struct i2c_target_data *)arg;
+
+	/*TODO: put board telemetry here*/
+
+	/* Only check fisrt byte from received data */
+	if (data->wr_buffer_idx >= 1) {
+		if (data->wr_buffer_idx == 1) {
+			uint8_t reg_offset = data->target_wr_msg.msg[0];
+			size_t struct_size = 0;
+			for (int i = 0; i < ARRAY_SIZE(telemetry_info_table); i++) {
+				if (telemetry_info_table[i].telemetry_offset == reg_offset) {
+					struct_size = telemetry_info_table[i].data_size;
+					break;
+				}
+			}
+			// Make sure the target buffer is not exceeded when reading
+			if (struct_size > sizeof(data->target_rd_msg.msg)) {
+				struct_size = sizeof(data->target_rd_msg.msg);
+			}
+			switch (reg_offset) {
+			case SENSOR_INIT_DATA_0_REG:
+			case SENSOR_INIT_DATA_1_REG: {
+				data->target_rd_msg.msg_length = struct_size;
+				memcpy(data->target_rd_msg.msg,
+				       sensor_init_data_0_1_table[reg_offset -
+								  SENSOR_INIT_DATA_0_REG],
+				       struct_size);
+			} break;
+			case SENSOR_READING_0_REG:
+			case SENSOR_READING_1_REG:
+			case SENSOR_READING_2_REG:
+			case SENSOR_READING_3_REG: {
+				data->target_rd_msg.msg_length = struct_size;
+				memcpy(data->target_rd_msg.msg,
+				       sensor_init_data_2_5_table[reg_offset - SENSOR_READING_0_REG],
+				       struct_size);
+			} break;
+			case INVENTORY_IDS_REG: {
+				data->target_rd_msg.msg_length = struct_size;
+				memcpy(data->target_rd_msg.msg,
+				       sensor_init_data_6_table[reg_offset - INVENTORY_IDS_REG],
+				       struct_size);
+			} break;
+			default:
+				LOG_ERR("Unknown reg offset: 0x%02x", reg_offset);
+				data->target_rd_msg.msg_length = 1;
+				data->target_rd_msg.msg[0] = 0xFF;
+				break;
+			}
+		} else {
+			LOG_ERR("Received data length: 0x%02x", data->wr_buffer_idx);
+			data->target_rd_msg.msg_length = 1;
+			data->target_rd_msg.msg[0] = 0xFF;
+		}
+	}
+	return false;
+}
+
+void sensor_data_table_init(void)
+{
+	uint8_t buffer_size = 0;
+	for (int i = 0; i < ARRAY_SIZE(telemetry_info_table); i++) {
+		if (telemetry_info_table[i].sensor_data_init) {
+			bool success = telemetry_info_table[i].sensor_data_init(
+				&telemetry_info_table[i], &buffer_size);
+			if (!success) {
+				LOG_ERR("initialize sensor data at offset 0x%02X",
+					telemetry_info_table[i].telemetry_offset);
+			}
+			telemetry_info_table[i].data_size = buffer_size;
+		}
+	}
+}
+
 /* I2C target init-config table */
 const struct _i2c_target_config I2C_TARGET_CONFIG_TABLE[MAX_TARGET_NUM] = {
-	{ 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0x40, 0xA }, { 0xFF, 0xA }, { 0x40, 0xA },
-	{ 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA },
+	{ 0xFF, 0xA },
+	{ 0xFF, 0xA },
+	{ 0xFF, 0xA },
+	{ 0x40, 0xA },
+	{ 0xFF, 0xA },
+	{ 0xFF, 0xA },
+	{ 0x40, 0xA, command_reply_data_handle },
+	{ 0xFF, 0xA },
+	{ 0xFF, 0xA },
+	{ 0xFF, 0xA },
+	{ 0xFF, 0xA },
+	{ 0xFF, 0xA },
 };

--- a/meta-facebook/minerva-ag/src/platform/plat_i2c_target.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_i2c_target.h
@@ -23,4 +23,45 @@
 #define TARGET_ENABLE 1
 #define TARGET_DISABLE 0
 
+#define TELEMETRY_BUFF_SIZE 255
+
+#define SENSOR_INIT_DATA_0_REG 0x00
+#define SENSOR_INIT_DATA_1_REG 0x01
+#define SENSOR_READING_0_REG 0x02
+#define SENSOR_READING_1_REG 0x03
+#define SENSOR_READING_2_REG 0x04
+#define SENSOR_READING_3_REG 0x05
+#define INVENTORY_IDS_REG 0x06
+#define OWL_NIC_MAC_ADDRESSES_REG 0x07 //not used
+#define STRAP_CAPABILTITY_REG 0x08
+#define WRITE_STRAP_PIN_VALUE_REG 0x09
+
+#define FRU_BOARD_PART_NUMBER_REG 0x60
+#define FRU_BOARD_SERIAL_NUMBER_REG 0x61
+#define FRU_BOARD_PRODUCT_NAME_REG 0x62
+#define FRU_BOARD_CUSTOM_DATA_1_REG 0x63
+#define FRU_BOARD_CUSTOM_DATA_2_REG 0x64
+#define FRU_BOARD_CUSTOM_DATA_3_REG 0x65
+#define FRU_BOARD_CUSTOM_DATA_4_REG 0x66
+
+#define FRU_PRODUCT_NAME_REG 0x70
+#define FRU_PRODUCT_PART_NUMBER_REG 0x71
+#define FRU_PRODUCT_PART_VERSION_REG 0x72
+#define FRU_PRODUCT_SERIAL_NUMBER_REG 0x73
+#define FRU_PRODUCT_ASSET_TAG_REG 0x74
+#define FRU_PRODUCT_CUSTOM_DATA_1_REG 0x75
+#define FRU_PRODUCT_CUSTOM_DATA_2_REG 0x76
+
+void update_sensor_data_2_5_table(void);
+void sensor_data_table_init(void);
+
+typedef struct _telemetry_info_ telemetry_info;
+
+typedef struct _telemetry_info_ {
+	uint8_t telemetry_offset;
+	uint16_t data_size;
+	bool (*sensor_data_init)(telemetry_info *, uint8_t *);
+
+} telemetry_info;
+
 #endif

--- a/meta-facebook/minerva-ag/src/platform/plat_i2c_target.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_i2c_target.h
@@ -53,6 +53,7 @@
 #define FRU_PRODUCT_CUSTOM_DATA_2_REG 0x76
 
 void update_sensor_data_2_5_table(void);
+void update_sensor_data_8_table(void);
 void sensor_data_table_init(void);
 
 typedef struct _telemetry_info_ telemetry_info;

--- a/meta-facebook/minerva-ag/src/platform/plat_i2c_target.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_i2c_target.h
@@ -36,6 +36,10 @@
 #define STRAP_CAPABILTITY_REG 0x08
 #define WRITE_STRAP_PIN_VALUE_REG 0x09
 
+#define I2C_BRIDGE_COMMAND_REG 0x40
+#define I2C_BRIDGE_COMMAND_STATUS_REG 0x41
+#define I2C_BRIDGE_COMMAND_RESPONSE_REG 0x42
+
 #define FRU_BOARD_PART_NUMBER_REG 0x60
 #define FRU_BOARD_SERIAL_NUMBER_REG 0x61
 #define FRU_BOARD_PRODUCT_NAME_REG 0x62
@@ -51,6 +55,12 @@
 #define FRU_PRODUCT_ASSET_TAG_REG 0x74
 #define FRU_PRODUCT_CUSTOM_DATA_1_REG 0x75
 #define FRU_PRODUCT_CUSTOM_DATA_2_REG 0x76
+
+typedef enum i2c_bridge_command_error {
+	I2C_BRIDGE_COMMAND_SUCCESS = 0,
+	I2C_BRIDGE_COMMAND_IN_PROCESS,
+	I2C_BRIDGE_COMMAND_FAILURE,
+} i2c_bridge_command_error;
 
 void update_sensor_data_2_5_table(void);
 void update_sensor_data_8_table(void);

--- a/meta-facebook/minerva-ag/src/platform/plat_init.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_init.c
@@ -75,6 +75,7 @@ void pal_post_init()
 	init_fru_info();
 	init_load_eeprom_log();
 	init_cpld_polling();
+	sensor_data_table_init();
 
 	LOG_INF("Init done");
 }

--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
@@ -7352,6 +7352,7 @@ pldm_sensor_info plat_pldm_sensor_temp_table[] = {
 			.sample_count = SAMPLE_COUNT_DEFAULT,
 			.cache = 0,
 			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.post_sensor_read_hook = post_all_sensor_read,
 		},
 	},
 };

--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.h
@@ -216,6 +216,8 @@
 #define VR_ASIC_P1V2_VDDHTX_PCIE_CURR_A 0x61
 #define VR_ASIC_P1V2_VDDHTX_PCIE_PWR_W 0x62
 
+#define PLAT_SENSOR_NUM_MAX 0x63 //Change if there is new sensor
+
 #define TMP75_TEMP_OFFSET 0x00
 #define UPDATE_INTERVAL_1S 1
 #define UPDATE_INTERVAL_5S 5


### PR DESCRIPTION
Summary:
- Support i2c telemetry command
- Support reg: 0x00 ~ 0x05
- Support part of reg: 0x06
- Add comment on i2c_target_config: rd_data_collect_func
- Support fru product custom data
- Support i2c telemetry write command
- Support reg: 0x08 ~ 0x76
- modify bootstrap command with setting hex-value
- modify_telemetry_with_bootstrap_command, reg:0x09 
- modify telemetry offset 0x08 format
- Support i2c telemetry i2c bridge master write/read command
- Support reg: 0x40 ~ 0x42

Test Plan:
- Build code: PASS